### PR TITLE
Add pitch frontend

### DIFF
--- a/Backend/foot-near-by-backend/src/pitch/pitch.controller.ts
+++ b/Backend/foot-near-by-backend/src/pitch/pitch.controller.ts
@@ -21,6 +21,7 @@ export class PitchController {
     getAllPitches() {
         return this.pitchService.getAllPitches();
     }
+
     @Get('getById/:id')
     getPitchById(@Param('id') id: number) {
         return this.pitchService.getPitchById(id);

--- a/Frontend/foot-nearby/App.js
+++ b/Frontend/foot-nearby/App.js
@@ -6,15 +6,14 @@ import LoginScreen from "./screens/LoginScreen";
 import SignupScreen from "./screens/SignupScreen";
 import WelcomeScreenPlayer from "./screens/Joueur/WelcomeScreenPlayer";
 import WelcomeScreenManager from "./screens/responsable/WelcomeScreenManager";
-
-
+import AddPitchScreen from "./screens/responsable/AddPitchScreen";
 
 const Stack = createStackNavigator();
 
 const App = () => {
   return (
     <NavigationContainer>
-      <Stack.Navigator initialRouteName="Home">
+      <Stack.Navigator initialRouteName="AddPitch">
         <Stack.Screen
           name="Home"
           component={HomeScreen}
@@ -30,10 +29,21 @@ const App = () => {
           component={SignupScreen}
           options={{ title: "Sign up" }}
         />
-        <Stack.Screen name="WelcomeScreenPlayer" component={WelcomeScreenPlayer}
-          options={{ headerShown: false }} />
-        <Stack.Screen name="WelcomeScreenManager" component={WelcomeScreenManager}
-          options={{ headerShown: false }} />
+        <Stack.Screen
+          name="WelcomeScreenPlayer"
+          component={WelcomeScreenPlayer}
+          options={{ headerShown: false }}
+        />
+        <Stack.Screen
+          name="WelcomeScreenManager"
+          component={WelcomeScreenManager}
+          options={{ headerShown: false }}
+        />
+        <Stack.Screen
+          name="AddPitch"
+          component={AddPitchScreen}
+          options={{ title: "Add a Pitch" }}
+        />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/Frontend/foot-nearby/android/app/src/debug/AndroidManifest.xml
+++ b/Frontend/foot-nearby/android/app/src/debug/AndroidManifest.xml
@@ -2,6 +2,10 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+
 
     <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning" tools:replace="android:usesCleartextTraffic" />
 </manifest>

--- a/Frontend/foot-nearby/package-lock.json
+++ b/Frontend/foot-nearby/package-lock.json
@@ -8,6 +8,7 @@
       "name": "foot-nearby",
       "version": "1.0.0",
       "dependencies": {
+        "@react-native-community/geolocation": "^3.4.0",
         "@react-native-mapbox-gl/maps": "^8.6.0-beta.0",
         "@react-native-picker/picker": "^2.10.2",
         "@react-navigation/bottom-tabs": "^7.2.0",
@@ -16,6 +17,8 @@
         "@react-navigation/stack": "^7.0.18",
         "axios": "^1.7.9",
         "expo": "~52.0.18",
+        "expo-image-picker": "^16.0.3",
+        "expo-location": "^18.0.4",
         "expo-status-bar": "~2.0.0",
         "foot-nearby": "file:",
         "react": "18.3.1",
@@ -3007,6 +3010,18 @@
         "node": ">=14"
       }
     },
+    "node_modules/@react-native-community/geolocation": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/geolocation/-/geolocation-3.4.0.tgz",
+      "integrity": "sha512-bzZH89/cwmpkPMKKveoC72C4JH0yF4St5Ceg/ZM9pA1SqX9MlRIrIrrOGZ/+yi++xAvFDiYfihtn9TvXWU9/rA==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/@react-native-mapbox-gl/maps": {
       "version": "8.6.0-beta.0",
       "resolved": "https://registry.npmjs.org/@react-native-mapbox-gl/maps/-/maps-8.6.0-beta.0.tgz",
@@ -5534,6 +5549,25 @@
         "react": "*"
       }
     },
+    "node_modules/expo-image-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.0.0.tgz",
+      "integrity": "sha512-Eg+5FHtyzv3Jjw9dHwu2pWy4xjf8fu3V0Asyy42kO+t/FbvW/vjUixpTjPtgKQLQh+2/9Nk4JjFDV6FwCnF2ZA==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-16.0.3.tgz",
+      "integrity": "sha512-c4IOqIQOtx8puWWU4fVsJhuGiAhH6gAIdrVzhimOXSEUHnfxCckRYzvznbd/0cuvaA5y9H0CSYrxpTUc/0WNVw==",
+      "dependencies": {
+        "expo-image-loader": "~5.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-keep-awake": {
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-14.0.1.tgz",
@@ -5541,6 +5575,14 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-location": {
+      "version": "18.0.4",
+      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-18.0.4.tgz",
+      "integrity": "sha512-OrZTxRpfi4bCJxjW186wt3kfoe0FHwXceE6dXdbxvjxnwMP9cbKeqY6Y2M1bVwboq7PI2eV/e1rOaGq+F+fZyw==",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {

--- a/Frontend/foot-nearby/package.json
+++ b/Frontend/foot-nearby/package.json
@@ -9,6 +9,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@react-native-community/geolocation": "^3.4.0",
     "@react-native-mapbox-gl/maps": "^8.6.0-beta.0",
     "@react-native-picker/picker": "^2.10.2",
     "@react-navigation/bottom-tabs": "^7.2.0",
@@ -17,6 +18,8 @@
     "@react-navigation/stack": "^7.0.18",
     "axios": "^1.7.9",
     "expo": "~52.0.18",
+    "expo-image-picker": "^16.0.3",
+    "expo-location": "^18.0.4",
     "expo-status-bar": "~2.0.0",
     "foot-nearby": "file:",
     "react": "18.3.1",

--- a/Frontend/foot-nearby/screens/responsable/AddPitchScreen.js
+++ b/Frontend/foot-nearby/screens/responsable/AddPitchScreen.js
@@ -1,0 +1,277 @@
+import React, { useState, useEffect } from "react";
+import {
+  View,
+  Text,
+  TextInput,
+  Button,
+  StyleSheet,
+  ScrollView,
+  Alert,
+  Image,
+  TouchableOpacity,
+  FlatList,
+} from "react-native";
+import MapView, { Marker } from "react-native-maps";
+import { Picker } from "@react-native-picker/picker";
+import * as Location from "expo-location";
+import * as ImagePicker from "expo-image-picker";
+
+import PitchService from "../../services/PitchService";
+
+const AddPitchScreen = () => {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [address, setAddress] = useState("");
+  const [latitude, setLatitude] = useState(37.78825);
+  const [longitude, setLongitude] = useState(-122.4324);
+  const [pricePerHour, setPricePerHour] = useState("");
+  const [capacity, setCapacity] = useState(5);
+  const [images, setImages] = useState([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        let { status } = await Location.requestForegroundPermissionsAsync();
+        if (status !== "granted") {
+          Alert.alert(
+            "Permission Denied",
+            "Permission to access location was denied."
+          );
+          return;
+        }
+
+        let userLocation = await Location.getCurrentPositionAsync({
+          accuracy: Location.Accuracy.High,
+        });
+
+        setLatitude(userLocation.coords.latitude);
+        setLongitude(userLocation.coords.longitude);
+      } catch (error) {
+        Alert.alert("Error", "Unable to fetch location.");
+        console.error(error);
+      }
+    })();
+  }, []);
+
+  const pickImage = async () => {
+    if (images.length >= 5) {
+      Alert.alert("Limit Reached", "You can only select up to 5 images.");
+      return;
+    }
+
+    let permissionResult =
+      await ImagePicker.requestMediaLibraryPermissionsAsync();
+
+    if (permissionResult.status !== "granted") {
+      Alert.alert(
+        "Permission Denied",
+        "Permission to access the gallery was denied."
+      );
+      return;
+    }
+
+    let result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      allowsEditing: true,
+      aspect: [4, 3],
+      quality: 1,
+    });
+
+    if (result.assets && result.assets[0]?.uri) {
+      setImages((prevImages) => [...prevImages, result.assets[0].uri]);
+    } else {
+      Alert.alert("Error", "No image selected.");
+    }
+  };
+
+  const removeImage = (index) => {
+    setImages(images.filter((_, i) => i !== index));
+  };
+
+  const handleMapPress = (event) => {
+    const { latitude, longitude } = event.nativeEvent.coordinate;
+    setLatitude(latitude);
+    setLongitude(longitude);
+  };
+
+  const handleSubmit = async () => {
+    const pitchData = {
+      name,
+      description,
+      address,
+      location: {
+        type: "Point",
+        coordinates: [parseFloat(longitude), parseFloat(latitude)],
+      },
+      pricePerHour: parseFloat(pricePerHour),
+      capacity: parseInt(capacity),
+      images: images,
+    };
+
+    try {
+      const response = await PitchService.addPitch(pitchData);
+      Alert.alert("Success", "Pitch added successfully!");
+      console.log("Response:", response);
+    } catch (error) {
+      Alert.alert("Error", "Failed to add pitch. Please try again.");
+    }
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.title}>Add a New Pitch</Text>
+      <TextInput
+        style={styles.input}
+        placeholder="Name"
+        value={name}
+        onChangeText={setName}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Description"
+        value={description}
+        onChangeText={setDescription}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Address"
+        value={address}
+        onChangeText={setAddress}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Price Per Hour"
+        value={pricePerHour}
+        onChangeText={setPricePerHour}
+        keyboardType="numeric"
+      />
+      <Text style={styles.subtitle}>Pitch Type</Text>
+      <View style={styles.pickerContainer}>
+        <Picker
+          selectedValue={capacity}
+          onValueChange={(itemValue) => setCapacity(Number(itemValue))}
+          style={styles.picker}
+        >
+          <Picker.Item label="5v5" value="5" />
+          <Picker.Item label="7v7" value="7" />
+          <Picker.Item label="9v9" value="9" />
+          <Picker.Item label="11v11" value="11" />
+        </Picker>
+      </View>
+      <View style={styles.imagePickerContainer}>
+        <TouchableOpacity style={styles.imagePickerButton} onPress={pickImage}>
+          <Text style={styles.imagePickerText}>Select Images</Text>
+        </TouchableOpacity>
+        <FlatList
+          data={images}
+          horizontal
+          keyExtractor={(item, index) => index.toString()}
+          contentContainerStyle={styles.imagesPreview}
+          renderItem={({ item, index }) => (
+            <View style={styles.imageWrapper}>
+              <Image source={{ uri: item }} style={styles.previewImage} />
+              <TouchableOpacity
+                style={styles.removeButton}
+                onPress={() => removeImage(index)}
+              >
+                <Text style={styles.removeButtonText}>X</Text>
+              </TouchableOpacity>
+            </View>
+          )}
+        />
+      </View>
+      <Text style={styles.subtitle}>Select Location on Map</Text>
+      <MapView
+        style={styles.map}
+        region={{
+          latitude: latitude,
+          longitude: longitude,
+          latitudeDelta: 0.01,
+          longitudeDelta: 0.01,
+        }}
+        onPress={handleMapPress}
+      >
+        <Marker coordinate={{ latitude, longitude }} />
+      </MapView>
+      <Button title="Add Pitch" onPress={handleSubmit} />
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flexGrow: 1, padding: 16, backgroundColor: "#fff" },
+  title: { fontSize: 24, fontWeight: "bold", marginBottom: 16 },
+  subtitle: { fontSize: 18, fontWeight: "600", marginBottom: 8 },
+  input: {
+    height: 50,
+    borderColor: "#ccc",
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingHorizontal: 15,
+    marginBottom: 16,
+  },
+  pickerContainer: {
+    marginBottom: 16,
+    borderWidth: 1,
+    borderColor: "#ccc",
+    borderRadius: 10,
+    overflow: "hidden",
+    backgroundColor: "#fff",
+  },
+  picker: {
+    height: 53,
+    width: "100%",
+    paddingHorizontal: 8,
+    color: "#333",
+  },
+  map: {
+    height: 300,
+    width: "100%",
+    marginBottom: 16,
+  },
+  imagePickerContainer: {
+    marginBottom: 16,
+  },
+  imagePickerButton: {
+    backgroundColor: "#007BFF",
+    padding: 10,
+    borderRadius: 5,
+    alignItems: "center",
+    marginBottom: 10,
+  },
+  imagePickerText: {
+    color: "#fff",
+    fontWeight: "bold",
+  },
+  imagesPreview: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  imageWrapper: {
+    position: "relative",
+    marginRight: 10,
+  },
+  previewImage: {
+    width: 80,
+    height: 80,
+    borderRadius: 5,
+  },
+  removeButton: {
+    position: "absolute",
+    top: 5,
+    right: 5,
+    backgroundColor: "grey",
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  removeButtonText: {
+    color: "#fff",
+    fontSize: 12,
+    fontWeight: "bold",
+  },
+});
+
+export default AddPitchScreen;

--- a/Frontend/foot-nearby/screens/responsable/components/TabNavigator.js
+++ b/Frontend/foot-nearby/screens/responsable/components/TabNavigator.js
@@ -1,28 +1,48 @@
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import ProfileScreen from "../ProfileScreeen";
 
-import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
+import MaterialCommunityIcons from "react-native-vector-icons/MaterialCommunityIcons";
 import { View } from "react-native";
 import TerrainsScreen from "../TerrainsScreen";
 
 const Tab = createBottomTabNavigator(); //creation d’ une instance du Tab.Navigator en utilisant createBottomTabNavigator
 const TabNavigator = (props) => {
-    return ( /* Définir les écrans dans le Tab.Navigator */
-        <View style={{ flex: 1 }}>
-            <Tab.Navigator initialRouteName="Profile">
-
-                <Tab.Screen name="Profile" component={ProfileScreen} options={{
-                    tabBarIcon: ({ color, size }) => (<MaterialCommunityIcons name="account" size={size} color={color} style={{ width: '30' }} />),
-                    tabBarLabel: 'Profile'
-                }} />
-                <Tab.Screen name="Terrains" component={TerrainsScreen} options={{
-                    tabBarIcon: ({ color, size }) => (<MaterialCommunityIcons name="soccer" size={size} color={color} style={{ width: '30' }} />),
-                    tabBarLabel: 'Terrains'
-                }} />
-
-            </Tab.Navigator>
-        </View>
-
-    )
-}
+  return (
+    /* Définir les écrans dans le Tab.Navigator */
+    <View style={{ flex: 1 }}>
+      <Tab.Navigator initialRouteName="Profile">
+        <Tab.Screen
+          name="Profile"
+          component={ProfileScreen}
+          options={{
+            tabBarIcon: ({ color, size }) => (
+              <MaterialCommunityIcons
+                name="account"
+                size={size}
+                color={color}
+                style={{ width: "30" }}
+              />
+            ),
+            tabBarLabel: "Profile",
+          }}
+        />
+        <Tab.Screen
+          name="Terrains"
+          component={TerrainsScreen}
+          options={{
+            tabBarIcon: ({ color, size }) => (
+              <MaterialCommunityIcons
+                name="soccer"
+                size={size}
+                color={color}
+                style={{ width: "30" }}
+              />
+            ),
+            tabBarLabel: "Terrains",
+          }}
+        />
+      </Tab.Navigator>
+    </View>
+  );
+};
 export default TabNavigator;

--- a/Frontend/foot-nearby/services/PitchService.js
+++ b/Frontend/foot-nearby/services/PitchService.js
@@ -1,0 +1,17 @@
+import axios from "axios";
+
+const API_URL = "http://192.168.1.102:3000/pitch";
+
+const PitchService = {
+  addPitch: async (pitchData) => {
+    try {
+      const response = await axios.post(`${API_URL}/add`, pitchData);
+      return response.data;
+    } catch (error) {
+      console.error("Error adding pitch:", error.response || error);
+      throw error;
+    }
+  },
+};
+
+export default PitchService;

--- a/Frontend/foot-nearby/services/authService.js
+++ b/Frontend/foot-nearby/services/authService.js
@@ -2,7 +2,7 @@ import axios from "axios";
 import { getUser, setUser, user } from "../sharedData/data";
 import User from "../models/User";
 
-const API_URL = "http://172.20.3.117:3000/auth";
+const API_URL = "http://192.168.1.102:3000/auth";
 
 const authService = {
   login: async (email, password, setError) => {
@@ -23,13 +23,8 @@ const authService = {
       }
       return null;
     }
-
   },
-  register: async (
-    name,
-    email,
-    password,
-    phoneNumber, role, setError) => {
+  register: async (name, email, password, phoneNumber, role, setError) => {
     try {
       console.log("sending request...");
       const rsp = await axios.post(`${API_URL}/register`, {
@@ -37,7 +32,7 @@ const authService = {
         email,
         password,
         phoneNumber,
-        role
+        role,
       });
       if (rsp.status != 200) {
         console.log("Error");
@@ -55,7 +50,6 @@ const authService = {
 
       return null;
     }
-
   },
   //resetPassword: (email) => axios.post(`${API_URL}/reset-password`, { email }),
 };


### PR DESCRIPTION
### Description du Commit :
Ce commit ajoute la fonctionnalité permettant aux utilisateurs d'ajouter un "_pitch_" à travers un formulaire interactif. Les principales fonctionnalités incluses sont les suivantes :

- **Formulaire de Pitch** : Le formulaire permet à l'utilisateur de saisir les informations essentielles du pitch, notamment le nom, la description, l'adresse, le prix par heure et la capacité.

- **Sélecteur d'Image** : L'utilisateur peut sélectionner jusqu'à 5 images depuis sa galerie à l'aide d'un sélecteur d'image. Les images sélectionnées sont affichées en miniature, et l'utilisateur peut les supprimer si nécessaire.

- **Sélecteur de Localisation** : La localisation du pitch peut être choisie sur une carte, permettant à l'utilisateur de positionner précisément l'emplacement via un marqueur.

- **Sélecteur de Type de Capacité** : Un Picker permet de choisir la capacité du terrain (5v5, 7v7, 9v9, ou 11v11) en fonction de la taille de l'équipe.

### Changements notables :

- Intégration de la fonctionnalité de carte via `react-native-maps` pour sélectionner la localisation.
- Utilisation de `expo-image-picker` pour la sélection des images.
- Amélioration de l'UX/UI pour la gestion des images et de la localisation.

### Actions nécessaires :

- Tester l'intégration de la carte et vérifier la sélection d'images.
- Vérifier le bon envoi des données du formulaire lors de la soumission.